### PR TITLE
Improve room response embed

### DIFF
--- a/roombot/utils/roomembed.py
+++ b/roombot/utils/roomembed.py
@@ -44,10 +44,10 @@ class RoomEmbed():
                 (" and {} more.".format(total_player - player_show_limit) if total_player > player_show_limit else "")
             )
         ).add_field(
-            name=self.get_text('host'),
+            name=self.get_text('Host'),
             value="<@{}>".format(self.room.host)
         ).add_field(
-            name=self.get_text('channel'),
+            name=self.get_text('Channel'),
             value="<#{}>".format(self.room.channel_id)
         ).add_field(
             name=room_status,

--- a/roombot/utils/roomembed.py
+++ b/roombot/utils/roomembed.py
@@ -29,15 +29,20 @@ class RoomEmbed():
 
     def get_embed(self):
         description = discord.Embed.Empty if self.room.description == '' else self.room.description
-        room_status = self.get_text('room_status').format(self.room.size - len(self.room.players)) if len(self.room.players) < self.room.size else self.get_text('full_room')
+        total_player = len(self.room.players)
+        player_show_limit = 5
+        room_status = self.get_text('room_status').format(self.room.size - total_player) if total_player < self.room.size else self.get_text('full_room')
         return discord.Embed(
             color=self.room.color,
             description=description,
             timestamp=self.room.created,
             title="{}{}".format(self.room.get_symbols(), self.room.activity)
         ).add_field(
-            name="{} ({}/{})".format(self.get_text('players'), len(self.room.players), self.room.size),
-            value="<@{}>".format(">, <@".join([str(id) for id in self.room.players]))
+            name="{} ({}/{})".format(self.get_text('players'), total_player, self.room.size),
+            value=(
+                "<@{}>".format(">, <@".join([str(id) for id in self.room.players[:player_show_limit]])) +
+                (" and {} more.".format(total_player - player_show_limit) if total_player > player_show_limit else "")
+            )
         ).add_field(
             name=self.get_text('host'),
             value="<@{}>".format(self.room.host)


### PR DESCRIPTION
This PR addresses two issues in room response embed:
1. Too many members
The bot will send the following errors if the `Players` field exceeds 1024 bytes due to too many members:
```
Command raised an exception: HTTPException: 400 Bad Request (error code: 50035): Invalid Form Body
In embed.fields.0.value: Must be 1024 or fewer in length.
```
This PR addressess this by capping the amount of member shown to 5, and add in a "and ... more" message. This comes with some minor refactoring.

2. Incorrect capitalisation
Some field name in the room response embed is not capitalised correctly. This PR also improves this as well.